### PR TITLE
Release documentation: CalVer changelog, versioning guide, README cleanup, monthly tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,210 @@
+# Changelog
+
+All notable changes to this project are documented here. Releases follow [calendar versioning](docs/VERSIONING.md) (`YYYY.M.patch`, for example `2026.4.0` for the April 2026 line). Each GitHub **Release** and git **tag** `vYYYY.M.0` marks the repository state at the end of that calendar month (or the latest commit when documenting the current month).
+
+## [Unreleased]
+
+### Planned
+
+- Continue curating monthly entries from conventional commits where possible.
+
+---
+
+## [2026.4.0] - 2026-04-23
+
+**Tag:** `v2026.4.0` (month-to-date snapshot; April still in progress)
+
+### Finanzas y reportes
+
+- Hub de evidencia de concreto por orden: Excel, ZIP, PDF de texto, fechas locales y sincronización del worker de PDF.js.
+- Exportación de remisiones completas, mano de obra y bombeo hacia reporte de clientes; bundles ZIP con conteos de preflight.
+- Auditoría de órdenes/cotizaciones y APIs asociadas; descargas desde almacenamiento.
+- Reporte semanal de cumplimiento (RR.HH. / finanzas) con APIs y selector de columnas arrastrable.
+- Tendencias del dashboard de ventas acotadas al rango de fechas del reporte.
+- Ajustes en revisadas (scroll, doble clic para inspección), chunks de `order_id` para evidencia, y lectura contable por planta en exportación de compras.
+
+### Compras e inventario
+
+- Reconciliación de flotilla: pestaña, APIs y exportación Excel.
+- Exportación y métricas contables (L/m³/kg), join `po_item`, copia TSV; sincronización de precios en OC y planta en exportación ERP.
+- Toneladas de OC de flotilla desde báscula (kg); realce de saldos en ficha de cliente y división del espacio de trabajo de compras.
+- Flujo de evidencia en entradas: subida directa a Storage, tipos de archivo flexibles, reintentos en móvil y estados por archivo.
+- Recalculo FIFO al eliminar entradas; edición de proveedor en revisión de precios; correcciones en creación de proveedor (RLS, UX) y modal de OC.
+
+### Cumplimiento y calidad
+
+- Disputas de hallazgos, plantillas EMA y UI de conjuntos/verificaciones.
+- APIs de vista previa de disputas, incidentes y composición de correo.
+- Parámetros de ruta EMA, trazabilidad y navegación a Validaciones.
+
+### Cotizaciones y otros
+
+- Validadores de crédito pueden crear y aprobar cotizaciones.
+- Comentarios internos Arkik y reasignaciones; compliance diario.
+- Administración de bombeo para dosificadores (remisiones propias); alcance de evidencia por rol.
+
+---
+
+## [2026.3.0] - 2026-03-31
+
+### Compras e inventario
+
+- Refactor amplio del módulo de compras: flujo documental homogéneo, alertas en órdenes de compra, cierres y snapshots, consumos por periodo y ajustes de inventario.
+- Cambios profundos en inventario y enlace con materiales ERP (alertas, solicitudes).
+- Precios en entradas de inventario y revisión de conciliación OC–entrada.
+
+### Calidad y producción
+
+- Módulo de trazabilidad de instrumentos EMA (NMX-EC-17025).
+- Quality Hub: layout, dashboard y documentación de apoyo.
+- Mejoras en visualización de muestreos y modelo de recetas desde Arkik.
+
+### Operaciones y finanzas
+
+- Producción y facturación multi-planta; página de resultado de acción en cotización.
+- Pagos de clientes en finanzas alineados a política de validación; notificación de aprobación de cotización.
+- Columna de planta en cotizaciones aprobadas y refinamiento de pestañas de aprobación.
+
+### Plataforma
+
+- Actualización de Node.js y npm; dependencias y parches de seguridad en lockfile.
+- Documentación de revisión de seguridad e invitaciones portal BIT.
+
+---
+
+## [2026.2.0] - 2026-02-28
+
+### Seguridad y plataforma
+
+- Endurecimiento tras incidente de seguridad: capas adicionales y redirección de rutas no autorizadas.
+- Sistema de anuncios de versión (release announcement) en aplicación.
+- BotID y utilidades relacionadas.
+
+### Módulos mayores
+
+- Compras (procurement) e inventario: APIs y UI estabilizadas; documentación de panorama de base ERP.
+- Productos adicionales y tareas de aprobación en dashboard.
+- Listas de precios (implementación parcial) y mejoras en gobernanza de versiones de receta.
+
+### Arkik y recetas
+
+- Creación de receta desde Arkik (modal, servicio, derivación de materiales, parser de código).
+- Correcciones de gobernanza y calculadora (unicidad, recuperación, detalle de materiales).
+
+### Pedidos y finanzas
+
+- Rediseño de UX de pedidos (pestañas, filtros, layout tipo glass).
+- Mejoras en aprobaciones pendientes, exportación de saldos y análisis de tiempos de orden.
+- Implementación FIFO de crédito en órdenes de compra.
+
+---
+
+## [2026.1.0] - 2026-01-31
+
+- Optimización de carga de Arkik y remisiones (modo bulk, menos tormentas de triggers).
+- Ajustes de gobernanza de versiones de receta y restricciones por cantidades bajas.
+- Correcciones de unidad de negocio en calidad, planta por defecto y duplicados de materiales en Arkik.
+- Notificaciones de validación de crédito (refactors en edge functions).
+- Documentación de optimización RLS y análisis de rendimiento.
+
+---
+
+## [2025.12.0] - 2025-12-30
+
+- Gobernanza de recetas y editor de cantidades de materiales; productos adicionales.
+- Pagos de clientes y tablero de pagos diarios; pestaña de cotizaciones aprobadas y RBAC en cotizaciones.
+- BotID y reglas de firewall en Vercel; matching de órdenes Arkik.
+- Rendimiento de calculadora y guardado de recetas (menos saturación al servidor).
+- Reporte semanal de remisiones para RR.HH.; métricas de consistencia en portal de clientes.
+
+---
+
+## [2025.11.0] - 2025-11-28
+
+- Refactor de tarjetas y navegación de pedidos; UI tipo glass y sistema de colores.
+- Refactor del cotizador y flujo de creación de pedidos para clientes externos.
+- Traducciones y revisiones del portal de clientes y administración de usuarios.
+- Correcciones de hidratación, gráficas de calidad y carga (loader, logo).
+
+---
+
+## [2025.10.0] - 2025-10-30
+
+- Portal de calidad y dossier; estudios de caracterización con reporte PDF.
+- Resumen de precios en entradas de inventario; reloj checador.
+- Mejoras en portal de clientes (saldo, sitio de calidad) y en página de pedidos (estados de carga).
+- Ajustes en detalle de pedido, matching de precios y APIs del dashboard.
+
+---
+
+## [2025.9.0] - 2025-09-30
+
+- Página de aterrizaje; mejoras en ventas e históricos.
+- Caracterización y ajustes en programación de órdenes.
+- Análisis de recetas y actualizaciones del procesador Arkik.
+
+---
+
+## [2025.8.0] - 2025-08-30
+
+- Carga de muestreos, adjuntos y ajustes continuos del procesador Arkik.
+- Gráficas de ventas extendidas y correcciones en reportes y listados de pedidos.
+- Mejoras en garantías, ensayos y flujo de archivos.
+
+---
+
+## [2025.7.0] - 2025-07-31
+
+- Soporte multi-planta y cambios amplios en conciencia de planta.
+- Carga de recetas y correcciones en listados de pedidos y zonas horarias.
+
+---
+
+## [2025.6.0] - 2025-06-30
+
+- Edición de remisiones; exportación a Excel.
+- Permisos para validador de crédito al dar de alta clientes.
+- Correcciones en recetas y flujo de crédito.
+
+---
+
+## [2025.5.0] - 2025-05-30
+
+- Reportes diarios y de agenda; pagos diarios.
+- Mejoras en detalle de pedido, filtros y servicios de pedidos.
+- Precio manual de bomba; integración con Google Maps.
+- Roles nuevos y recetas enlazadas a partidas de pedido.
+
+---
+
+## [2025.4.0] - 2025-04-30
+
+- Migración a Tailwind CSS v4 y ajustes de UI (OKLCH, componentes).
+- Remisiones y navegación de pedidos; dashboard financiero.
+- Endurecimiento de seguridad y despliegue (documentación de deployment).
+
+---
+
+## [2025.3.0] - 2025-03-12
+
+- Cimientos del sistema de cotizaciones sobre Next.js y Supabase.
+- Flujos de autenticación, invitaciones y recuperación de contraseña.
+- Configuración de Vercel, script de build y compatibilidad con Next.
+
+---
+
+[Unreleased]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2026.4.0...HEAD
+[2026.4.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2026.3.0...v2026.4.0
+[2026.3.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2026.2.0...v2026.3.0
+[2026.2.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2026.1.0...v2026.2.0
+[2026.1.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.12.0...v2026.1.0
+[2025.12.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.11.0...v2025.12.0
+[2025.11.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.10.0...v2025.11.0
+[2025.10.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.9.0...v2025.10.0
+[2025.9.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.8.0...v2025.9.0
+[2025.8.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.7.0...v2025.8.0
+[2025.7.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.6.0...v2025.7.0
+[2025.6.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.5.0...v2025.6.0
+[2025.5.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.4.0...v2025.5.0
+[2025.4.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/compare/v2025.3.0...v2025.4.0
+[2025.3.0]: https://github.com/dssolutions-mx/cotizaciones-concreto/commits/v2025.3.0

--- a/README.md
+++ b/README.md
@@ -1,138 +1,59 @@
-# Sistema de Visualización de Historial de Precios
+# Cotizaciones Concreto
 
-Este sistema permite visualizar el historial de precios de recetas por cliente en una aplicación web desarrollada con Next.js 14, Supabase, TypeScript y Tailwind CSS.
+Aplicación web para **cotizaciones, pedidos, finanzas, compras, inventario y calidad** del negocio de concreto. Está construida con **Next.js** (App Router), **React**, **TypeScript**, **Supabase** y **Tailwind CSS**.
 
-## Características
+## Versiones y releases
 
-- Visualización tabular y gráfica de precios históricos
-- Filtrado por cliente o receta
-- Búsqueda y filtros por rango de fechas
-- Indicadores de tendencias y cambios porcentuales
-- Interfaz moderna y responsiva
-- Soporte para múltiples clientes y recetas
-- Linting configurado para mantener la calidad del código
+- **[CHANGELOG.md](./CHANGELOG.md)** — Notas por mes (línea de tiempo alineada con el historial del repositorio).
+- **[docs/VERSIONING.md](./docs/VERSIONING.md)** — Esquema CalVer (`YYYY.M.patch`), tags `vYYYY.M.0` y proceso para publicar en GitHub Releases.
 
-## Requisitos Previos
+La versión actual del paquete está en `package.json` y debe actualizarse junto con el changelog al cerrar cada mes.
 
-- Node.js 18.x o superior
-- npm o yarn
-- Base de datos Supabase configurada
+## Requisitos
 
-## Configuración del Proyecto
+- **Node.js** ≥ 20.19.0 (ver `package.json` → `engines`)
+- **npm** ≥ 10
+- Proyecto **Supabase** con variables de entorno configuradas
 
-1. Instalar dependencias:
+## Configuración rápida
 
 ```bash
 npm install
 ```
 
-2. Configurar variables de entorno:
-
-Crear un archivo `.env.local` con las siguientes variables:
+Crear `.env.local` con al menos:
 
 ```env
-NEXT_PUBLIC_SUPABASE_URL=tu_url_de_supabase
-NEXT_PUBLIC_SUPABASE_ANON_KEY=tu_clave_anonima_de_supabase
+NEXT_PUBLIC_SUPABASE_URL=https://tu-proyecto.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=tu_clave_anon
 ```
 
-3. Iniciar el servidor de desarrollo:
+Inicio en desarrollo:
 
 ```bash
 npm run dev
 ```
 
-## Estructura del Proyecto
+Compilación de producción (usa `build.js` del repositorio):
 
-```
-src/
-  ├── app/                    # Páginas y rutas de la aplicación
-  ├── components/            # Componentes reutilizables
-  │   ├── ui/               # Componentes de interfaz de usuario
-  │   ├── PriceHistoryTable.tsx
-  │   └── PriceHistoryChart.tsx
-  ├── services/             # Servicios y lógica de negocio
-  │   └── priceHistoryService.ts
-  ├── types/               # Definiciones de tipos TypeScript
-  │   └── priceHistory.ts
-  └── lib/                 # Utilidades y funciones auxiliares
-      ├── utils.ts
-      └── formatters.ts
+```bash
+npm run build
+npm start
 ```
 
-## Uso
+## Calidad de código
 
-1. Acceder a la página de historial de precios en `/dashboard/price-history`
-2. Seleccionar el modo de visualización (tabla o gráfico)
-3. Filtrar por cliente o receta según necesidad
-4. Utilizar los filtros de fecha y búsqueda para refinar resultados
+```bash
+npm run lint
+```
 
-## Tecnologías Utilizadas
+Guía de reglas ESLint: [MDFILES/LINTING.md](./MDFILES/LINTING.md).
 
-- Next.js 14
-- TypeScript
-- Tailwind CSS
-- Supabase
-- Recharts
-- shadcn/ui
-- React Day Picker
-- date-fns
+## Documentación adicional
 
-## Desarrollo
-
-Para contribuir al proyecto:
-
-1. Crear una rama para la nueva característica
-2. Implementar cambios siguiendo los estándares de código
-3. Ejecutar pruebas y asegurar que no hay errores
-4. Crear un pull request con una descripción detallada
+- [MDFILES/DOCUMENTATION.md](./MDFILES/DOCUMENTATION.md) — Visión general del sistema.
+- [docs/README.md](./docs/README.md) — Índice de guías (despliegue, flujo de desarrollo, CI).
 
 ## Licencia
 
-MIT 
-
-## Dashboard Optimization
-
-The dashboard has been optimized with the following improvements:
-
-1. **API Route-based Data Fetching**:
-   - Created separate API routes for different dashboard data sections
-   - Each route implements caching with appropriate Cache-Control headers
-   - API routes can be called in parallel for better performance
-
-2. **Data Caching with SWR**:
-   - Implemented SWR (stale-while-revalidate) for client-side data fetching
-   - Data is cached in the browser memory for faster subsequent renders
-   - Each data section has its own revalidation strategy
-
-3. **Progressive Loading**:
-   - Dashboard now shows skeleton loaders during data fetching
-   - Components load progressively with staggered animations
-   - UI is responsive even when data is still loading
-
-4. **Component Atomization**:
-   - Separated dashboard into smaller, focused components
-   - Each component handles its own loading state
-   - Better memory and performance management
-
-5. **Reduced Animation Cost**:
-   - Optimized animation timings and stagger effects
-   - Reduced animation complexity for better performance
-   - Shortened animation duration for faster perceived load times
-
-These optimizations significantly improve the dashboard load time and provide a smoother user experience, especially for users with slower connections. 
-
-## Calidad de Código y Linting
-
-El proyecto utiliza ESLint para mantener un alto estándar de calidad de código. Hemos configurado reglas que ayudan a prevenir errores comunes y promueven buenas prácticas de desarrollo.
-
-Para obtener más información sobre las reglas de linting y cómo resolver las advertencias comunes, consulta el archivo [LINTING.md](./LINTING.md).
-
-Para ejecutar el linter:
-
-```bash
-# Ejecutar el linter
-npx next lint
-
-# Corregir automáticamente los problemas que se puedan solucionar
-npx next lint --fix
-``` # Force redeploy Tue Oct  7 03:15:56 CST 2025
+MIT

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,10 +7,12 @@ This directory contains comprehensive documentation for the Concrete Quotation S
 - [Deployment Guide](./DEPLOYMENT.md) - How to deploy the application to production
 - [Development Workflow](./DEVELOPMENT_WORKFLOW.md) - Guide for development process and Git workflow
 - [CI/CD Setup](./CI_CD_SETUP.md) - Setting up Continuous Integration and Deployment
+- [Versioning and releases](./VERSIONING.md) - CalVer, tags, and GitHub Releases workflow
+- [Changelog](../CHANGELOG.md) - Monthly release notes
 
 ## Additional Resources
 
-The main project documentation is available in the root [DOCUMENTATION.md](../DOCUMENTATION.md) file.
+The main project overview is in [MDFILES/DOCUMENTATION.md](../MDFILES/DOCUMENTATION.md).
 
 ## Contributing to Documentation
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,40 @@
+# Versioning and releases
+
+This repository uses **calendar versioning (CalVer)** for product releases documented on GitHub and in [CHANGELOG.md](../CHANGELOG.md).
+
+## Scheme
+
+- **Format:** `YYYY.M.patch` (npm-compatible semver).
+- **Marketing / Git tag:** `vYYYY.M.0` for the monthly baseline (for example `v2026.4.0`).
+- **Meaning:**
+  - `YYYY` — year.
+  - `M` — month number without leading zero (4 = April).
+  - `patch` — optional corrections during that month (documentation-only hotfixes, cherry-picks). Most monthly snapshots stay at `.0`.
+
+The `version` field in [package.json](../package.json) reflects the **current release line** (typically the latest closed month or the in-progress month after updating the changelog).
+
+## Monthly release process
+
+1. **Freeze the changelog** — Move items from `[Unreleased]` in `CHANGELOG.md` into a new section `[YYYY.M.0] - YYYY-MM-DD` using the last day of the month (or today if you are cutting mid-month and naming it clearly).
+2. **Bump `package.json`** — Set `"version"` to `YYYY.M.0` (or the appropriate patch).
+3. **Tag the tree** — Create an annotated tag on the commit that should represent that month (usually the last commit merged in that month):
+
+   ```bash
+   git tag -a v2026.4.0 -m "Release 2026.4.0 (April 2026)"
+   git push -u origin your-branch
+   git push origin v2026.4.0
+   ```
+
+4. **GitHub Release** — From the repository **Releases** page, choose “Draft a new release”, select the tag, title `YYYY.M.0 — Month YYYY`, and paste the corresponding section from `CHANGELOG.md` as the description.
+
+## Historical tags
+
+Tags `v2025.3.0` … `v2026.4.0` point to month-end snapshots (or month-to-date for the current period) so the history is navigable even before GitHub Releases were curated.
+
+## Relation to in-app announcements
+
+The application may show a release announcement driven by configuration such as `src/config/releaseAnnouncement.ts`. When you publish a version, align that constant with the same version string users should see, if applicable.
+
+## Commits
+
+Prefer [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, scopes) so future changelog sections can be generated or audited more easily.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cotizaciones-concreto",
-  "version": "0.1.0",
+  "version": "2026.4.0",
   "private": true,
   "scripts": {
     "postinstall": "node scripts/sync-pdfjs-worker.mjs",

--- a/scripts/tag-monthly-release.sh
+++ b/scripts/tag-monthly-release.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Create an annotated monthly tag. Usage:
+#   ./scripts/tag-monthly-release.sh 2026 4
+# Requires: clean working tree, correct HEAD checked out for the release snapshot.
+
+set -euo pipefail
+
+year="${1:-}"
+month="${2:-}"
+
+if [[ ! "$year" =~ ^20[0-9]{2}$ ]] || [[ ! "$month" =~ ^(1[0-2]|[1-9])$ ]]; then
+  echo "Usage: $0 <YYYY> <M>   (M = 1-12, no leading zero required)" >&2
+  exit 1
+fi
+
+tag="v${year}.${month}.0"
+month_name="$(python3 -c "import calendar as c; print(c.month_name[int('${month}')], '${year}')")"
+msg="Release ${year}.${month}.0 (${month_name})"
+
+if git rev-parse "$tag" >/dev/null 2>&1; then
+  echo "Tag $tag already exists." >&2
+  exit 1
+fi
+
+git tag -a "$tag" -m "$msg"
+echo "Created annotated tag $tag"
+echo "Push with: git push origin $tag"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This pull request establishes a clear **versions and releases** story for the repository, similar in spirit to the curated approach used on the mantenimiento project.

## Changes

- Added **[CHANGELOG.md](CHANGELOG.md)** with **monthly** release sections from March 2025 through April 2026, grouped by functional area (finanzas, compras, calidad, plataforma) instead of raw noisy commit subjects.
- Added **[docs/VERSIONING.md](docs/VERSIONING.md)** describing **CalVer** (`YYYY.M.patch`), git tags `vYYYY.M.0`, and a repeatable process for GitHub Releases.
- Replaced the root **README** that described only “price history” and contained broken links with a concise project overview, correct Node/npm requirements from `package.json`, and links to changelog and versioning docs.
- Updated **[docs/README.md](docs/README.md)** to point to `MDFILES/DOCUMENTATION.md`, changelog, and versioning guide (removed the broken `../DOCUMENTATION.md` link).
- Set **`package.json` version** to `2026.4.0` to match the current documented release line.
- Added **[scripts/tag-monthly-release.sh](scripts/tag-monthly-release.sh)** as a small helper for future annotated tags.

## Git tags (already pushed)

Annotated tags **`v2025.3.0` … `v2026.4.0`** were created and pushed so the **Releases** page and compare URLs in the changelog resolve to real points in history. **`v2026.4.0`** points at this branch tip so it includes the new changelog and versioning documentation.

## Follow-up for maintainers

1. On GitHub **Releases**, create one release per tag (or start with 2026.x) by pasting the matching section from `CHANGELOG.md`.
2. Note: **`npm run lint`** currently invokes `next lint`, which is not present in Next.js 16’s CLI in this environment; CI only runs `npm run build`. Fixing lint invocation is a separate change if desired.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d862d51-521b-448a-9b6d-6dbe8705d2cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d862d51-521b-448a-9b6d-6dbe8705d2cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

