### PR TITLE
EMA Centro: certificados vigentes, PDF visible y documentación clara

### DIFF
--- a/src/app/api/ema/instrumentos/[id]/certificados/route.ts
+++ b/src/app/api/ema/instrumentos/[id]/certificados/route.ts
@@ -37,7 +37,7 @@ const CreateCertSchema = z.object({
   observaciones: z.string().optional().nullable(),
 });
 
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const supabase = await createServerSupabaseClient();
@@ -50,7 +50,14 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
     if (!readRole || !READ_ROLES.includes(readRole))
       return NextResponse.json({ error: 'Sin permisos' }, { status: 403 });
 
-    const certs = await getCertificadosByInstrumento(id);
+    const { searchParams } = new URL(req.url);
+    const vigenteParam = searchParams.get('vigente');
+    const vigente = vigenteParam === 'true' || vigenteParam === '1';
+    const limitRaw = searchParams.get('limit');
+    const limitParsed = limitRaw != null ? parseInt(limitRaw, 10) : NaN;
+    const limit = Number.isFinite(limitParsed) && limitParsed > 0 ? limitParsed : undefined;
+
+    const certs = await getCertificadosByInstrumento(id, { vigente, limit });
     const withPdf = await Promise.all(
       certs.map(async (c) => {
         const pdf_url = await createCalibrationCertificateSignedUrl(supabase, c.archivo_path, 3600);

--- a/src/app/quality/instrumentos/[id]/page.tsx
+++ b/src/app/quality/instrumentos/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState, useEffect, useCallback } from 'react'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import {
   ArrowLeft,
@@ -22,6 +22,8 @@ import {
   Pencil,
   FileSignature,
   Trash2,
+  FileWarning,
+  RefreshCw,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -47,7 +49,16 @@ import {
   publishedPlantillaSummaryFromTemplatesPayload,
   type PublishedPlantillaSummary,
 } from '@/lib/ema/publishedPlantillaFromTemplatesResponse'
-import type { InstrumentoDetalle, InstrumentoTrazabilidad, CompletedVerificacionCard, EmaDeleteBlocker } from '@/types/ema'
+import type {
+  CertificadoCalibracion,
+  InstrumentoDetalle,
+  InstrumentoTrazabilidad,
+  CompletedVerificacionCard,
+  EmaDeleteBlocker,
+} from '@/types/ema'
+
+/** API augments DB row with a time-limited signed URL for the PDF. */
+type CertificadoCalibracionConPdf = CertificadoCalibracion & { pdf_url: string | null }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -72,17 +83,17 @@ function formatDate(dateStr: string | null): string {
 
 // ─── Page ────────────────────────────────────────────────────────────────────
 
+const EMA_DETAIL_TABS = ['certificados', 'verificaciones', 'incidentes', 'trazabilidad'] as const
+type EmaDetailTab = (typeof EMA_DETAIL_TABS)[number]
+
 export default function InstrumentoDetailPage() {
   const { id } = useParams<{ id: string }>()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { hasRole } = useAuthSelectors()
 
   const [instrumento, setInstrumento] = useState<InstrumentoDetalle | null>(null)
-  const [certificadoVigente, setCertificadoVigente] = useState<{
-    laboratorio_externo: string
-    fecha_vencimiento: string
-    fecha_emision: string
-  } | null>(null)
+  const [certificadoVigente, setCertificadoVigente] = useState<CertificadoCalibracionConPdf | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -123,16 +134,8 @@ export default function InstrumentoDetailPage() {
 
       if (certRes.ok) {
         const certJ = await certRes.json()
-        const certs = certJ.data ?? []
-        if (certs.length > 0) {
-          setCertificadoVigente({
-            laboratorio_externo: certs[0].laboratorio_externo,
-            fecha_vencimiento: certs[0].fecha_vencimiento,
-            fecha_emision: certs[0].fecha_emision,
-          })
-        } else {
-          setCertificadoVigente(null)
-        }
+        const certs: CertificadoCalibracionConPdf[] = certJ.data ?? []
+        setCertificadoVigente(certs[0] ?? null)
       } else {
         setCertificadoVigente(null)
       }
@@ -152,6 +155,17 @@ export default function InstrumentoDetailPage() {
 
   useEffect(() => { load() }, [load])
 
+  const defaultTab: EmaDetailTab = instrumento?.tipo === 'C' ? 'verificaciones' : 'certificados'
+  const [activeTab, setActiveTab] = useState<EmaDetailTab>('certificados')
+
+  useEffect(() => {
+    if (!instrumento) return
+    const t = searchParams.get('tab')
+    const fromUrl =
+      t && (EMA_DETAIL_TABS as readonly string[]).includes(t) ? (t as EmaDetailTab) : null
+    setActiveTab(fromUrl ?? defaultTab)
+  }, [instrumento?.id, instrumento?.tipo, searchParams, defaultTab])
+
   if (loading) return <LoadingSkeleton />
 
   if (error || !instrumento) {
@@ -170,7 +184,6 @@ export default function InstrumentoDetailPage() {
 
   const days = daysUntil(instrumento.fecha_proximo_evento)
   const isUrgent = instrumento.estado === 'vencido' || instrumento.estado === 'proximo_vencer'
-  const defaultTab = instrumento.tipo === 'C' ? 'verificaciones' : 'certificados'
 
   return (
     <div className="flex flex-col gap-4">
@@ -203,7 +216,15 @@ export default function InstrumentoDetailPage() {
           </div>
 
           {/* Actions */}
-          <div className="flex items-center gap-2 pl-9 sm:pl-0">
+          <div className="flex items-center gap-2 pl-9 sm:pl-0 flex-wrap">
+            {instrumento.tipo !== 'C' && certificadoVigente?.pdf_url && (
+              <Button size="sm" variant="outline" className="border-sky-200 bg-sky-50/80 text-sky-900 gap-1.5" asChild>
+                <a href={certificadoVigente.pdf_url} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  Ver certificado vigente
+                </a>
+              </Button>
+            )}
             {isUrgent && instrumento.tipo !== 'C' && (
               <Button size="sm" className="bg-sky-700 hover:bg-sky-800 text-white gap-1.5" asChild>
                 <Link href={`/quality/instrumentos/${id}/certificar`}>
@@ -304,7 +325,20 @@ export default function InstrumentoDetailPage() {
 
       {/* ── Tabbed Sections ───────────────────────────────────── */}
       <div className="rounded-lg border border-stone-200 bg-white overflow-hidden">
-        <Tabs defaultValue={defaultTab}>
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => {
+            const next = v as EmaDetailTab
+            setActiveTab(next)
+            const nextParams = new URLSearchParams(searchParams.toString())
+            if (next === defaultTab) nextParams.delete('tab')
+            else nextParams.set('tab', next)
+            const qs = nextParams.toString()
+            router.replace(qs ? `/quality/instrumentos/${id}?${qs}` : `/quality/instrumentos/${id}`, {
+              scroll: false,
+            })
+          }}
+        >
           <div className="border-b border-stone-200 bg-stone-50/80 px-1 pt-1">
             <TabsList className="h-auto bg-transparent gap-0 p-0">
               <TabButton value="certificados" icon={<Award className="h-3.5 w-3.5" />} label="Certificados" />
@@ -315,7 +349,7 @@ export default function InstrumentoDetailPage() {
           </div>
 
           <TabsContent value="certificados" className="m-0">
-            <CertificadosSection instrumentoId={id} />
+            <CertificadosSection instrumentoId={id} instrumentoTipo={instrumento.tipo} onRefresh={load} />
           </TabsContent>
           <TabsContent value="verificaciones" className="m-0">
             <VerificacionesSection
@@ -502,9 +536,14 @@ function TraceabilityCard({
   certificadoVigente,
 }: {
   instrumento: InstrumentoDetalle
-  certificadoVigente: { laboratorio_externo: string; fecha_vencimiento: string; fecha_emision: string } | null
+  certificadoVigente: CertificadoCalibracionConPdf | null
 }) {
   const tipo = instrumento.tipo
+  const certDocHref = certificadoVigente?.pdf_url ?? undefined
+  const certFichaHref =
+    certificadoVigente && !certificadoVigente.pdf_url
+      ? `/quality/instrumentos/${instrumento.id}?tab=certificados`
+      : undefined
 
   return (
     <section className="rounded-lg border border-stone-200 bg-white p-4 md:p-5">
@@ -523,11 +562,24 @@ function TraceabilityCard({
               title="Laboratorio EMA externo"
               subtitle={certificadoVigente?.laboratorio_externo ?? 'Sin certificado vigente'}
               detail={certificadoVigente
-                ? `Vence: ${certificadoVigente.fecha_vencimiento}`
+                ? [
+                    certificadoVigente.numero_certificado && `#${certificadoVigente.numero_certificado}`,
+                    `Emisión: ${certificadoVigente.fecha_emision}`,
+                    `Vence: ${certificadoVigente.fecha_vencimiento}`,
+                  ].filter(Boolean).join(' · ')
                 : undefined
               }
               status={certificadoVigente ? 'vigente' : 'vencido'}
               accent="sky"
+              href={certDocHref ?? certFichaHref}
+              hrefExternal={Boolean(certDocHref)}
+              hrefLabel={
+                certDocHref
+                  ? 'Abrir PDF del certificado'
+                  : certFichaHref
+                    ? 'Ver documentación en pestaña Certificados'
+                    : undefined
+              }
             />
             <TraceConnector />
           </>
@@ -586,7 +638,7 @@ function TraceabilityCard({
 }
 
 function TraceNode({
-  title, subtitle, detail, status, accent, isHighlighted, href,
+  title, subtitle, detail, status, accent, isHighlighted, href, hrefExternal, hrefLabel,
 }: {
   title: string
   subtitle: string
@@ -595,6 +647,9 @@ function TraceNode({
   accent: 'sky' | 'emerald' | 'stone' | 'violet'
   isHighlighted?: boolean
   href?: string
+  /** When true, `href` opens in a new tab (e.g. signed PDF URL). */
+  hrefExternal?: boolean
+  hrefLabel?: string
 }) {
   const statusDot = status === 'vigente'
     ? 'bg-emerald-400'
@@ -616,10 +671,20 @@ function TraceNode({
         {href && <ExternalLink className="h-3 w-3 text-stone-400 ml-auto" />}
       </div>
       <p className="text-sm font-medium text-stone-900 truncate">{subtitle}</p>
-      {detail && <p className="text-xs text-stone-500 font-mono mt-0.5">{detail}</p>}
+      {detail && <p className="text-xs text-stone-500 font-mono mt-0.5 break-words">{detail}</p>}
+      {href && hrefLabel && (
+        <p className="text-[11px] text-sky-700 font-medium mt-1.5">{hrefLabel}</p>
+      )}
     </div>
   )
 
+  if (href && hrefExternal) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className="flex-1 min-w-0 no-underline text-inherit">
+        {content}
+      </a>
+    )
+  }
   if (href) return <Link href={href} className="flex-1 min-w-0">{content}</Link>
   return content
 }
@@ -636,15 +701,52 @@ function TraceConnector() {
 
 // ─── Certificados Section ────────────────────────────────────────────────────
 
-function CertificadosSection({ instrumentoId }: { instrumentoId: string }) {
-  const [certs, setCerts] = useState<any[]>([])
+function CertificadosSection({
+  instrumentoId,
+  instrumentoTipo,
+  onRefresh,
+}: {
+  instrumentoId: string
+  instrumentoTipo: string
+  onRefresh: () => void | Promise<void>
+}) {
+  const [certs, setCerts] = useState<CertificadoCalibracionConPdf[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [listError, setListError] = useState<string | null>(null)
+
+  const loadCerts = useCallback(async () => {
+    setListError(null)
+    const res = await fetch(`/api/ema/instrumentos/${instrumentoId}/certificados`)
+    const j = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      setListError((j as { error?: string }).error ?? 'No se pudieron cargar los certificados')
+      setCerts([])
+      return
+    }
+    setCerts((j as { data?: CertificadoCalibracionConPdf[] }).data ?? [])
+  }, [instrumentoId])
 
   useEffect(() => {
-    fetch(`/api/ema/instrumentos/${instrumentoId}/certificados`)
-      .then(r => r.json())
-      .then(j => { setCerts(j.data ?? []); setLoading(false) })
-  }, [instrumentoId])
+    let cancelled = false
+    setLoading(true)
+    loadCerts().finally(() => {
+      if (!cancelled) setLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [loadCerts])
+
+  const handleRefreshList = async () => {
+    setRefreshing(true)
+    try {
+      await loadCerts()
+      await onRefresh()
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  const usesExternalCert = instrumentoTipo === 'A' || instrumentoTipo === 'B'
 
   if (loading) return <div className="py-10 text-center text-sm text-stone-400 animate-pulse">Cargando…</div>
 
@@ -653,55 +755,139 @@ function CertificadosSection({ instrumentoId }: { instrumentoId: string }) {
       <SectionHeader
         title="Certificados de calibración"
         action={
-          <Button size="sm" variant="outline" className="h-7 border-stone-300 text-stone-700 gap-1 text-xs" asChild>
-            <Link href={`/quality/instrumentos/${instrumentoId}/certificar`}>
-              <Plus className="h-3 w-3" /> Registrar
-            </Link>
-          </Button>
+          <div className="flex items-center gap-1.5">
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2 text-stone-500 gap-1 text-xs"
+              onClick={handleRefreshList}
+              disabled={refreshing}
+              title="Actualizar lista y resumen superior"
+            >
+              <RefreshCw className={cn('h-3 w-3', refreshing && 'animate-spin')} />
+              Actualizar
+            </Button>
+            {usesExternalCert && (
+              <Button size="sm" variant="outline" className="h-7 border-stone-300 text-stone-700 gap-1 text-xs" asChild>
+                <Link href={`/quality/instrumentos/${instrumentoId}/certificar`}>
+                  <Plus className="h-3 w-3" /> Añadir documentación
+                </Link>
+              </Button>
+            )}
+          </div>
         }
       />
+      {!usesExternalCert && (
+        <div className="mx-4 my-3 rounded-lg border border-stone-200 bg-stone-50/90 px-3 py-2 text-xs text-stone-600">
+          Los instrumentos <strong>Tipo C</strong> se sustentan con <strong>verificaciones internas</strong> frente a un patrón Tipo A. Esta pestaña solo aplica si hubo registros históricos de certificado externo.
+        </div>
+      )}
+      {listError && (
+        <div className="mx-4 my-3 rounded-lg border border-red-200 bg-red-50/80 px-3 py-2 text-xs text-red-800 flex items-start gap-2">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+          <span>{listError}</span>
+        </div>
+      )}
       {certs.length === 0 ? (
-        <EmptyTabState message="Sin certificados registrados" />
+        <div className="px-4 pb-6">
+          <EmptyTabState message="Sin certificados registrados" />
+          {usesExternalCert && (
+            <div className="mt-4 flex flex-col items-center gap-2">
+              <p className="text-xs text-stone-500 text-center max-w-md">
+                Suba el PDF emitido por el laboratorio acreditado y complete los datos metrológicos para cerrar la trazabilidad EMA.
+              </p>
+              <Button size="sm" className="bg-sky-700 text-white hover:bg-sky-800 gap-1.5" asChild>
+                <Link href={`/quality/instrumentos/${instrumentoId}/certificar`}>
+                  <Award className="h-3.5 w-3.5" />
+                  Registrar certificado y PDF
+                </Link>
+              </Button>
+            </div>
+          )}
+        </div>
       ) : (
         <div className="divide-y divide-stone-100">
-          {certs.map((c: any) => (
-            <div key={c.id} className={cn('flex items-start gap-3 px-4 py-3', c.is_vigente && 'bg-emerald-50/40')}>
-              <div className={cn(
-                'mt-0.5 h-2 w-2 rounded-full shrink-0',
-                c.is_vigente ? 'bg-emerald-500' : 'bg-stone-300'
-              )} />
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <span className="text-sm font-medium text-stone-900">{c.laboratorio_externo}</span>
-                  {c.is_vigente && (
-                    <span className="rounded-full bg-emerald-100 border border-emerald-200 px-2 py-0.5 text-[10px] font-medium text-emerald-700">
-                      Vigente
-                    </span>
-                  )}
-                </div>
-                <div className="font-mono text-xs text-stone-500 mt-0.5">
-                  {c.numero_certificado && `#${c.numero_certificado} · `}
-                  Emitido: {c.fecha_emision} · Vence: {c.fecha_vencimiento}
-                </div>
-                {c.archivo_nombre_original && (
-                  <p className="text-xs text-stone-600 mt-0.5 truncate" title={c.archivo_nombre_original}>
-                    Archivo: {c.archivo_nombre_original}
-                  </p>
+          {certs.map((c) => {
+            const hasStorageKey = Boolean(c.archivo_path?.trim())
+            const canOpenPdf = Boolean(c.pdf_url)
+            return (
+              <div
+                key={c.id}
+                className={cn(
+                  'flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-start sm:gap-3',
+                  c.is_vigente && 'bg-emerald-50/40',
                 )}
-                {c.observaciones && <p className="text-xs text-stone-500 mt-0.5">{c.observaciones}</p>}
+              >
+                <div className="flex flex-1 gap-3 min-w-0">
+                  <div className={cn(
+                    'mt-1.5 h-2 w-2 rounded-full shrink-0',
+                    c.is_vigente ? 'bg-emerald-500' : 'bg-stone-300',
+                  )} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-stone-900">{c.laboratorio_externo}</span>
+                      {c.is_vigente && (
+                        <span className="rounded-full bg-emerald-100 border border-emerald-200 px-2 py-0.5 text-[10px] font-medium text-emerald-700">
+                          Vigente
+                        </span>
+                      )}
+                    </div>
+                    <div className="font-mono text-xs text-stone-500 mt-0.5">
+                      {c.numero_certificado && `#${c.numero_certificado} · `}
+                      Emitido: {c.fecha_emision} · Vence: {c.fecha_vencimiento}
+                    </div>
+                    {c.acreditacion_laboratorio && (
+                      <p className="text-[11px] text-stone-600 mt-0.5">
+                        Acreditación: <span className="font-mono">{c.acreditacion_laboratorio}</span>
+                      </p>
+                    )}
+                    {c.archivo_nombre_original && (
+                      <p className="text-xs text-stone-600 mt-0.5 truncate" title={c.archivo_nombre_original}>
+                        Archivo: {c.archivo_nombre_original}
+                      </p>
+                    )}
+                    {c.observaciones && (
+                      <p className="text-xs text-stone-500 mt-0.5 line-clamp-2">{c.observaciones}</p>
+                    )}
+                    {!hasStorageKey && (
+                      <div className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50/90 px-2.5 py-2 text-xs text-amber-900">
+                        <FileWarning className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                        <span>
+                          Este registro no tiene PDF en almacén. Use <strong>Añadir documentación</strong> para cargar un certificado nuevo (el historial se conserva).
+                        </span>
+                      </div>
+                    )}
+                    {hasStorageKey && !canOpenPdf && (
+                      <div className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50/90 px-2.5 py-2 text-xs text-amber-900">
+                        <FileWarning className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                        <span>
+                          No se pudo generar el enlace de descarga (permisos de almacén o archivo faltante). Pulse <strong>Actualizar</strong> o contacte a administración.
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="flex flex-row flex-wrap sm:flex-col items-stretch sm:items-end justify-end gap-1.5 shrink-0 pl-5 sm:pl-0">
+                  {canOpenPdf && (
+                    <Button size="sm" variant="outline" className="h-7 border-sky-200 bg-sky-50/80 text-sky-900 gap-1 px-2 text-xs" asChild>
+                      <a href={c.pdf_url!} target="_blank" rel="noopener noreferrer">
+                        <ExternalLink className="h-3 w-3" /> Ver certificado (PDF)
+                      </a>
+                    </Button>
+                  )}
+                  {usesExternalCert && (
+                    <Button size="sm" variant="outline" className="h-7 border-stone-300 text-stone-700 gap-1 px-2 text-xs" asChild>
+                      <Link href={`/quality/instrumentos/${instrumentoId}/certificar`}>
+                        <Plus className="h-3 w-3" /> Nuevo PDF
+                      </Link>
+                    </Button>
+                  )}
+                  <span className="font-mono text-xs text-stone-400 self-center sm:self-end">{timeAgo(c.created_at)}</span>
+                </div>
               </div>
-              <div className="flex flex-col items-end gap-1.5 shrink-0">
-                {c.pdf_url ? (
-                  <Button size="sm" variant="outline" className="h-7 border-stone-300 text-stone-800 gap-1 px-2 text-xs" asChild>
-                    <a href={c.pdf_url} target="_blank" rel="noopener noreferrer">
-                      <ExternalLink className="h-3 w-3" /> Ver PDF
-                    </a>
-                  </Button>
-                ) : null}
-                <span className="font-mono text-xs text-stone-400">{timeAgo(c.created_at)}</span>
-              </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/app/quality/instrumentos/page.tsx
+++ b/src/app/quality/instrumentos/page.tsx
@@ -465,18 +465,27 @@ function ActionSection({
                 {daysLabel(days)}
               </span>
 
-              {/* Action link */}
-              <Link
-                href={`/quality/instrumentos/${inst.id}/${actionPath}`}
-                className={cn(
-                  'shrink-0 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
-                  actionPath === 'certificar'
-                    ? 'border-sky-200 bg-sky-50 text-sky-700 hover:bg-sky-100'
-                    : 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100',
+              <div className="flex flex-col items-end gap-1 shrink-0">
+                <Link
+                  href={`/quality/instrumentos/${inst.id}/${actionPath}`}
+                  className={cn(
+                    'rounded-md border px-3 py-1.5 text-xs font-medium transition-colors text-center',
+                    actionPath === 'certificar'
+                      ? 'border-sky-200 bg-sky-50 text-sky-700 hover:bg-sky-100'
+                      : 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100',
+                  )}
+                >
+                  {actionLabel} →
+                </Link>
+                {actionPath === 'certificar' && (
+                  <Link
+                    href={`/quality/instrumentos/${inst.id}?tab=certificados`}
+                    className="text-[10px] text-stone-500 hover:text-sky-700 underline-offset-2 hover:underline"
+                  >
+                    Ver certificados en ficha
+                  </Link>
                 )}
-              >
-                {actionLabel} →
-              </Link>
+              </div>
             </div>
           )
         })}

--- a/src/services/emaInstrumentoService.ts
+++ b/src/services/emaInstrumentoService.ts
@@ -734,13 +734,21 @@ export async function deleteConjunto(id: string): Promise<void> {
 
 export async function getCertificadosByInstrumento(
   instrumento_id: string,
+  opts?: { vigente?: boolean; limit?: number },
 ): Promise<CertificadoCalibracion[]> {
   const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
+  let query = supabase
     .from('certificados_calibracion')
     .select('*')
     .eq('instrumento_id', instrumento_id)
     .order('fecha_emision', { ascending: false });
+  if (opts?.vigente === true) {
+    query = query.eq('is_vigente', true);
+  }
+  if (opts?.limit != null && opts.limit > 0) {
+    query = query.limit(opts.limit);
+  }
+  const { data, error } = await query;
   if (error) throw error;
   return data ?? [];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

En el **Centro EMA** (`/quality/instrumentos`) la ficha de cada instrumento ya cargaba certificados, pero el resumen superior usaba `?limit=1&vigente=true` sin que el API lo aplicara (siempre devolvía el más reciente por emisión, no necesariamente el vigente). Además, el PDF solo aparecía de forma discreta en la pestaña Certificados.

## Cambios

- **API** `GET .../certificados`: respeta `vigente=true` y `limit` (filtra `is_vigente` y limita resultados en servicio).
- **Ficha del instrumento**: el certificado vigente cargado arriba coincide con el marcado vigente en BD e incluye `pdf_url` para enlaces directos.
- **Cadena de trazabilidad**: el nodo del laboratorio abre el **PDF en nueva pestaña** cuando hay URL firmada; si no hay PDF pero sí registro, enlaza a la pestaña Certificados (`?tab=certificados`).
- **Cabecera**: botón **Ver certificado vigente** (A/B) cuando hay PDF.
- **Pestaña Certificados**: botones más claros (**Ver certificado (PDF)**, **Nuevo PDF** / **Añadir documentación**), avisos si falta archivo o no se puede firmar la URL, **Actualizar** (lista + resumen), nota para Tipo C, estado vacío con CTA a registrar, y pestañas sincronizadas con la URL `?tab=`.
- **Dashboard Centro EMA**: en la lista de urgencias de certificación externa, enlace secundario **Ver certificados en ficha** hacia `?tab=certificados`.

## Pruebas

- `npm run lint` en este entorno falla porque el CLI de Next 16 no expone `lint` como subcomando instalado; no se ejecutó lint completo aquí. Cambios revisados con el analizador del IDE.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efed2b5d-ad77-4e4e-9807-1b9b95a3dcad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efed2b5d-ad77-4e4e-9807-1b9b95a3dcad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

